### PR TITLE
Changes made to align with some GitHub community standards

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "line_length": false,
+  "MD025": false
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at troy.forster@gmail.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ The prerequesites for contributing to this repo are the same is if you were deve
 - [Node.js v12.13.0 and NPM 6.14.5](https://nodejs.org/en/download/)
 - [Git 2.25](https://git-scm.com/downloads)
 
+## Usage 
+
 ```sh
 # Fork it from GitHub https://github.com/tforster/git-new/fork
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Prerequisites
+
+The prerequesites for contributing to this repo are the same is if you were developing with it.
+
+- A good code editor.
+- [Node.js v12.13.0 and NPM 6.14.5](https://nodejs.org/en/download/)
+- [Git 2.25](https://git-scm.com/downloads)
+
+```sh
+# Fork it from GitHub https://github.com/tforster/git-new/fork
+
+# Create your feature branch
+git checkout -b {meaninful-branch-name}
+
+# Commit your changes
+git commit -a"{meaninful commit message}"
+
+# Push to the branch
+git push origin {meaninful-branch-name}
+
+#Create a new Pull Request
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _A Git template for bootstrapping a variety of projects with a consistent set of
 
 ## Instructions
 
-1. Create your new repository by clicking the "Use this template" [button](https://github.com/tforster/git-new/generate) from the GitHub repository.
+1. Create your new repository by clicking the "Use this template" [button](https://github.com/tforster/git-new/generate) from the GitHub repository. (or download from https://github.com/tforster/git-new/archive/master.zip and unzip)
 1. Follow the GitHub prompts to complete the configuration of your new repository
 1. Clone your new repository to your local develop environment
 1. Install NPM dependencies including linters and code prettiers `npm i`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
-# Git New
+# Generic New Project Template
 
-_A cloneable Git template for repeatable and consistent project bootstraps_
+_A Git template for bootstrapping a variety of projects with a consistent set of control files._
 
-# Table of Contents
+## Instructions
 
-- [Git New](#git-new)
-- [Table of Contents](#table-of-contents)
+1. Create your new repository by clicking the "Use this template" [button](https://github.com/tforster/git-new/generate) from the GitHub repository.
+1. Follow the GitHub prompts to complete the configuration of your new repository
+1. Clone your new repository to your local develop environment
+1. Install NPM dependencies including linters and code prettiers `npm i`
+1. Edit [README.md](README.md)
+   - Edit the title to match your project
+   - Edit the description to describe your project
+   - Edit Prerequisites, Setup and Configuration, Usage, For Users and Meta sections
+1. Edit [package.json](package.json)
+   - Update the title to match the title of this README
+   - Update the description to match the description of this README
+   - Edit the semantic version to match your project requirements
+1. Update your LICENSE
+   - Edit the year and fullname variables in [LICENSE.txt](LICENSE.txt)
+   - The provided LICENSE file implements the MIT license as per [https://choosealicense.com/licenses/mit](https://choosealicense.com/licenses/mit)
+   - For closed source delete the LICENSE.txt file and update the package.json license property to "UNLICENSED"
+   - If neither MIT or UNLICENSED suit your needs consider creating a LICENSE.txt from [https://choosealicense.com/](https://choosealicense.com/)
+1. Update [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). For more information on code of conduct see [https://opensource.guide/code-of-conduct/](https://opensource.guide/code-of-conduct/)
+1. Update [CONTRIBUTING.md](CONTRIBUTING.md). For more information about open source contributions see [https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors](https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors)
+1. Delete any unwanted files in /docker (or the entire /docker folder if you're not containerising)
+1. Update [CHANGELOG.md](CHANGELOG.md)
+1. Delete this instruction block
+
+# Table of Content
+
+- [Generic New Project Template](#generic-new-project-template)
+  - [Instructions](#instructions)
+- [Table of Content](#table-of-content)
 - [Prerequisites](#prerequisites)
 - [Setup and Configuration](#setup-and-configuration)
 - [Usage](#usage)
@@ -13,7 +39,6 @@ _A cloneable Git template for repeatable and consistent project bootstraps_
 - [Change Log](#change-log)
 - [Meta](#meta)
 - [Contributing](#contributing)
-  - [Prerequisites](#prerequisites-1)
 
 # Prerequisites
 
@@ -33,41 +58,16 @@ git clone git@github.com:tforster/git-new.git /my/path/to/my/project-name
 
 # Usage
 
-This repository is intended to serve as a template for new projects by providing a consistent set of control files. Use it by cloning to your new project folder, editing some key properties and re-initialising the .git folder to remove this history and finally replacing the remote with your own.
-
-1. Switch to your new project folder `cd /my/path/to/my/project-name`
-1. Remove the git-new .git database `rm -rf .git`
-1. Install NPM dependencies including linters and code prettiers `npm i`
-1. Edit [README.md](README.md)
-   - Edit the title to match your project
-   - Edit the description to describe your project
-1. Edit [package.json](package.json)
-   - Update the title to match the title of this README
-   - Update the description to match the description of this README
-   - Edit the semantic version to match your project requirements
-1. Update your LICENSE
-   - Edit the year and fullname variables in [LICENSE.txt](LICENSE.txt)
-   - The provided LICENSE file implements the MIT license as per [https://choosealicense.com/licenses/mit](https://choosealicense.com/licenses/mit)
-   - For closed source delete the LICENSE.txt file and update the package.json license property to "UNLICENSED"
-   - If neither MIT or UNLICENSED suit your needs consider creating a LICENSE.txt from [https://choosealicense.com/](https://choosealicense.com/)
-1. Delete any unwanted files in /docker (or the entire /docker folder if you're not containerising)
-1. Update [CHANGELOG.md](CHANGELOG.md)
-1. Re-initialise .git `git init`
-1. Add your own repo's origin `git remote add origin {my-git-origin}`
-1. Update package.json to reflect the new origin and clean up any other properties by following the prompts `npm init`
-1. Delete this instruction block
-1. Stage and commit files `git add -A && git commit -m"Initial creation"`
-1. Push `git push -u origin master`
-1. Create a develop branch (workflow dependent) `git checkout -b develop && git push -u origin develop`
-1. Your project and repo are ready for your first feature branch `git checkout -b {my-feature-branch-name}`
+- Describe how your repository should be used.
+- Include any references to other repositories such as NPM, DockerHub, etc.
 
 # For Users
 
-Place instructions here if there is some form of installable or runable artifact intended for end users.
+- Use this optional section to describe to end users how to install or run release artifacts.
 
 # Change Log
 
-See [CHANGELOG.md](changelog.md)
+See [CHANGELOG.md](CHANGELOG.md)
 
 # Meta
 
@@ -79,27 +79,4 @@ See [LICENSE](LICENSE.md) for more information.
 
 # Contributing
 
-This section applies if you will be developing new features and fixing bugs for this repository.
-
-```sh
-# Fork it from GitHub https://github.com/tforster/git-new/fork
-
-# Create your feature branch
-git checkout -b {meaninful-branch-name}
-
-# Commit your changes
-git commit -a"{meaninful commit message}"
-
-# Push to the branch
-git push origin {meaninful-branch-name}
-
-#Create a new Pull Request
-```
-
-## Prerequisites
-
-The prerequesites for contributing to this repo are the same is if you were developing with it.
-
-- A good code editor.
-- [Node.js v12.13.0 and NPM 6.14.5](https://nodejs.org/en/download/)
-- [Git 2.25](https://git-scm.com/downloads)
+See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
I have been going through GitHub and GitHub settings and they've made a lot of changes recently. Two that are notable are:

1. You can now set a repo as a template. This adds a new button to the repo code tab titled "Use this template". Clicking the button steps you through the creation of a new repo under your selected account with a new name. It replaces a number of manual steps I had in my README.md instructions. I have since enabled this repo as a template and editing my instructions accordingly.
1.  Under Insights is a checklist of files to add to help build a community around an open-source project. See https://github.com/tforster/git-new/community. As a result, I have added a CODE_OF_CONDUCT.md and CONTRIBUTING.md to the template.

Aside from the above, I have been using a MarkDown linter for several years now to enforce consistency in my .md files. However, I disagree with two of its rules so I have added a .markdownlint.json file in the root to override them.

The net result of the above is the addition of several more files in the root. I feel they are justified, although in the case of the MarkDown linter rules, I would love to see a standard whereby ALL linting rules can come from a single .lintrulesrc.json file. I am going to see if .eslintrc.json can be coerced into being the source for markdown too.